### PR TITLE
Refactor Singleton to follow C++ best practices

### DIFF
--- a/engine/code/include/anthraxAI/utils/singleton.h
+++ b/engine/code/include/anthraxAI/utils/singleton.h
@@ -12,11 +12,15 @@ namespace Utils
             Singleton() = default;
 
         public:
-            static_assert(std::is_base_of_v<Singleton<T>, T>, "T must inherit from Singleton");
 
             Singleton(const Singleton* obj) = delete;
             Singleton* operator=(const Singleton*) = delete; 
 
-            static T* GetInstance() {  static T Instance; return std::addressof(Instance); }
+            static T* GetInstance()
+	    {
+		static_assert(std::is_base_of_v<Singleton<T>, T>, "T must inherit from Singleton");
+		static T Instance;
+		return std::addressof(Instance);
+	    }
     };
 }

--- a/engine/code/include/anthraxAI/utils/singleton.h
+++ b/engine/code/include/anthraxAI/utils/singleton.h
@@ -1,18 +1,22 @@
 #pragma once
 
+#include <memory>
+#include <type_traits>
+
 namespace Utils
 {
     template <typename T>
     class Singleton 
     {
-        private:
         protected:
-            Singleton() {}
+            Singleton() = default;
 
         public:
+            static_assert(std::is_base_of_v<Singleton<T>, T>, "T must inherit from Singleton");
+
             Singleton(const Singleton* obj) = delete;
             Singleton* operator=(const Singleton*) = delete; 
 
-            static T* GetInstance() {  static T Instance; return &Instance; }
+            static T* GetInstance() {  static T Instance; return std::addressof(Instance); }
     };
 }


### PR DESCRIPTION
 
This PR refactors the `Singleton` class to follow modern C++ practices:  

- Replaced empty constructor `Singleton() {}` with `= default` for clarity  
- Removed unnecessary empty `private:` section 
- Replaced `&` with `std::addressof` to prevent issues if `T` overloads `operator&`
- Added `static_assert(std::is_base_of_v<Singleton<T>, T>, ...)` to ensure correct usage of class  
