### PR TITLE
Two fixes for Ubuntu 24.04

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,13 @@
 # !/bin/bash
 
 cd assets
-../build/demos/demo-models/anthraxAI-demo-models
+
+# Ubuntu 24.04.02
+# attempts to launch `../build/demos/demo-models/anthraxAI-demo-models`
+# would return an `Core::Audio::Init(): Device was not created` error continually
+# a temporary fix:
+# forcing loading the system `openal` instead of the one built by anthrax
+# `build/engine/libs/openal-soft/openal-soft/libopenal.so.1`
+# `apt install libopenal1` if not installed
+
+LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libopenal.so.1 ../build/demos/demo-models/anthraxAI-demo-models

--- a/tools/linux/install-vulkan-sdk.sh
+++ b/tools/linux/install-vulkan-sdk.sh
@@ -6,7 +6,7 @@ install_vulkan_apt() {
     # Add LunarG public signing key
     wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
     # Add LunarG Vulkan repository
-    sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+    sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
     # Update package list and install Vulkan SDK
     sudo apt update
     sudo apt install vulkan-sdk -y


### PR DESCRIPTION
### Ubuntu Jammy to noble (24.04)

### Fixing `Core::Audio::Init(): Device was not created` error
Ubuntu 24.04.02
attempts to launch `../build/demos/demo-models/anthraxAI-demo-models`
would return an `Core::Audio::Init(): Device was not created` error continually
a temporary fix:
forcing loading the system `openal` instead of the one built by anthrax
`build/engine/libs/openal-soft/openal-soft/libopenal.so.1`
`apt install libopenal1` if not installed